### PR TITLE
Implementation of File sink

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -35,22 +35,22 @@ impl Handler {
     }
 
     pub fn debug(&mut self, message: &str) {
-        self.log_to_sinks(message, LogLevels::DEBUG);
+        self.log_to_sinks(message, LogLevels::Debug);
     }
 
     pub fn info(&mut self, message: &str) {
-        self.log_to_sinks(message, LogLevels::INFO);
+        self.log_to_sinks(message, LogLevels::Info);
     }
 
     pub fn warn(&mut self, message: &str) {
-        self.log_to_sinks(message, LogLevels::WARN);
+        self.log_to_sinks(message, LogLevels::Warn);
     }
 
     pub fn error(&mut self, message: &str) {
-        self.log_to_sinks(message, LogLevels::ERROR);
+        self.log_to_sinks(message, LogLevels::Error);
     }
 
     pub fn fatal(&mut self, message: &str) {
-        self.log_to_sinks(message, LogLevels::FATAL);
+        self.log_to_sinks(message, LogLevels::Fatal);
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,3 +1,5 @@
+use chrono::Local;
+
 use crate::sinks::base::{LogLevels, LogMessage};
 use std::error::Error;
 
@@ -19,8 +21,11 @@ impl Handler {
     }
 
     fn log_to_sinks(&mut self, message: &str, log_level: LogLevels) {
+        // Generate timestamp here so all sinks have the same timestamp
+        let timestamp: chrono::DateTime<Local> = Local::now();
+
         for s in self.sinks.iter_mut() {
-            s.log_message(&String::from(message), &log_level);
+            s.log_message(&String::from(message), timestamp, &log_level);
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,9 @@
 use chrono::Local;
 
-use crate::sinks::base::{LogLevels, LogMessage};
+use crate::{
+    sinks::base::{LogLevels, LogMessage},
+    utils::{self, generate_human_timestamp},
+};
 use std::error::Error;
 
 pub struct Handler {
@@ -13,16 +16,18 @@ impl Handler {
     }
 
     pub fn add_sink(&mut self, sink: Box<dyn LogMessage>) {
+        // Adds individual sinks to the handler
         self.sinks.push(sink)
     }
 
     pub fn set_sinks(&mut self, sinks: Vec<Box<dyn LogMessage>>) {
+        // Replaces the handler's entire vector with the incoming vector
         self.sinks = sinks
     }
 
     fn log_to_sinks(&mut self, message: &str, log_level: LogLevels) {
         // Generate timestamp here so all sinks have the same timestamp
-        let timestamp: chrono::DateTime<Local> = Local::now();
+        let timestamp: chrono::DateTime<Local> = utils::generate_human_timestamp();
 
         for s in self.sinks.iter_mut() {
             s.log_message(&String::from(message), timestamp, &log_level);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let new_stdout_sink = stdoutsink::StdoutSink::new().unwrap();
     let mut new_file_sink = filesink::FileSink::new(
         PathBuf::from("/home/mattnowzari/Documents/rust_projects/alembic/alembic.log"),
-        filesink::RotationPolicy::WEEKLY
-    ).unwrap();
+        filesink::RotationPolicy::WEEKLY,
+    )
+    .unwrap();
 
     new_file_sink.set_rotation_policy(filesink::RotationPolicy::HOURLY);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     logger.add_sink(Box::new(new_stdout_sink));
     logger.add_sink(Box::new(new_file_sink));
 
-    logger.debug("prior art");
-    logger.debug("huh");
-    logger.info("Wow this is so cool OOP in Rust");
-    logger.warn("WARNUNG WARNUNG");
+    logger.debug("println debugging is best debugging");
+    logger.info("Very informational");
+    logger.warn("WARNUNG");
     logger.error("! ERROR !");
-    logger.fatal("FATALITY");
+    logger.fatal("FATALITY.");
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let new_stdout_sink = stdoutsink::StdoutSink::new().unwrap();
     let mut new_file_sink = filesink::FileSink::new(
         PathBuf::from("/home/mattnowzari/Documents/rust_projects/alembic/alembic.log"),
-        filesink::RotationPolicy::WEEKLY,
+        filesink::RotationPolicy::Weekly,
     )
     .unwrap();
 
-    new_file_sink.set_rotation_policy(filesink::RotationPolicy::HOURLY);
+    new_file_sink.set_rotation_policy(filesink::RotationPolicy::Hourly);
 
     // logger.set_sinks(vec![new_stdout_sink, new_file_sink])?;
     logger.add_sink(Box::new(new_stdout_sink));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #[allow(dead_code, unused)]
 mod handler;
 mod sinks;
+mod utils;
 
 use crate::sinks::*;
 use std::{error::Error, path::PathBuf};

--- a/src/sinks/base.rs
+++ b/src/sinks/base.rs
@@ -3,20 +3,20 @@ use core::fmt;
 use chrono::Local;
 
 pub enum LogLevels {
-    DEBUG,
-    INFO,
-    WARN,
-    ERROR,
-    FATAL,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
 }
 impl fmt::Display for LogLevels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            LogLevels::DEBUG => write!(f, "DEBUG"),
-            LogLevels::INFO => write!(f, "INFO"),
-            LogLevels::WARN => write!(f, "WARN"),
-            LogLevels::ERROR => write!(f, "ERROR"),
-            LogLevels::FATAL => write!(f, "FATAL"),
+            LogLevels::Debug => write!(f, "DEBUG"),
+            LogLevels::Info => write!(f, "INFO"),
+            LogLevels::Warn => write!(f, "WARN"),
+            LogLevels::Error => write!(f, "ERROR"),
+            LogLevels::Fatal => write!(f, "FATAL"),
         }
     }
 }

--- a/src/sinks/base.rs
+++ b/src/sinks/base.rs
@@ -25,7 +25,7 @@ impl fmt::Display for LogLevels {
 pub trait LogMessage {
     fn log_message(
         &mut self,
-        message: &String,
+        message: &str,
         timestamp: chrono::DateTime<Local>,
         log_levels: &LogLevels,
     );

--- a/src/sinks/base.rs
+++ b/src/sinks/base.rs
@@ -1,5 +1,7 @@
 use core::fmt;
 
+use chrono::Local;
+
 pub enum LogLevels {
     DEBUG,
     INFO,
@@ -21,5 +23,10 @@ impl fmt::Display for LogLevels {
 
 /// All sinks must implement the LogMessage trait.
 pub trait LogMessage {
-    fn log_message(&mut self, message: &String, log_levels: &LogLevels);
+    fn log_message(
+        &mut self,
+        message: &String,
+        timestamp: chrono::DateTime<Local>,
+        log_levels: &LogLevels,
+    );
 }

--- a/src/sinks/filesink.rs
+++ b/src/sinks/filesink.rs
@@ -1,6 +1,6 @@
-use chrono::Local;
-use crate::utils;
 use super::base::{self};
+use crate::utils;
+use chrono::Local;
 use core::fmt;
 use std::{
     error::Error,
@@ -9,6 +9,12 @@ use std::{
     path::PathBuf,
     time::{Duration, SystemTime},
 };
+
+// Constants for file rotation policies
+const HOURLY: u64 = 3600;
+const DAILY: u64 = 86400;
+const WEEKLY: u64 = 604800;
+const MONTHLY: u64 = 2419200;
 
 #[allow(dead_code)]
 pub enum RotationPolicy {
@@ -100,22 +106,22 @@ impl FileSink {
             let mut is_stale = false;
             match self.rotation_policy {
                 RotationPolicy::Hourly => {
-                    if duration_since > Duration::from_secs(3600) {
+                    if duration_since > Duration::from_secs(HOURLY) {
                         is_stale = true;
                     }
                 }
                 RotationPolicy::Daily => {
-                    if duration_since > Duration::from_secs(86400) {
+                    if duration_since > Duration::from_secs(DAILY) {
                         is_stale = true;
                     }
                 }
                 RotationPolicy::Weekly => {
-                    if duration_since > Duration::from_secs(604800) {
+                    if duration_since > Duration::from_secs(WEEKLY) {
                         is_stale = true;
                     }
                 }
                 RotationPolicy::Monthly => {
-                    if duration_since > Duration::from_secs(2419200) {
+                    if duration_since > Duration::from_secs(MONTHLY) {
                         is_stale = true;
                     }
                 }

--- a/src/sinks/filesink.rs
+++ b/src/sinks/filesink.rs
@@ -1,6 +1,8 @@
 use chrono::Local;
 
-use super::base::{self, LogLevels};
+use crate::utils;
+
+use super::base::{self};
 use core::fmt;
 use std::{error::Error, fs::{self, File}, io::Write, path::PathBuf, time::{Duration, SystemTime}};
 
@@ -143,7 +145,8 @@ impl FileSink {
     }
 
     fn rename_existing_log_file(&mut self) -> Result<(), Box<dyn Error>> {
-        let timestamp: chrono::DateTime<Local> = Local::now();
+        // let timestamp: chrono::DateTime<Local> = Local::now();
+        let timestamp: String =  utils::generate_timestamp();
         // modify to unix timestamp
         // TODO - more sophisticated string manipulation!
         let new_logfile_name = format!("alembic.{:?}.log", timestamp);

--- a/src/sinks/filesink.rs
+++ b/src/sinks/filesink.rs
@@ -35,7 +35,6 @@ impl base::LogMessage for FileSink {
         self.rotate_log_file();
         // generate timestamp
         // TODO - timestamp should be generated once, not per-sink!
-        let timestamp: chrono::DateTime<Local> = Local::now();
         // prepare log message
         let prepared_message: String = self.prepare_log_message(
             message,
@@ -67,8 +66,6 @@ impl FileSink {
     }
 
     fn append_to_file(&mut self, message: &String) {
-        self.create_if_nonexistent();
-
         let mut openf = File::options()
             .append(true)
             .create(true)
@@ -78,14 +75,14 @@ impl FileSink {
             .expect("write failed");
     }
 
-    fn create_if_nonexistent(&mut self) {
-        let does_logfile_exist = fs::exists(self.filename
-            .clone())
-            .unwrap();
-        if does_logfile_exist == false {
-            self.create_new_log_file().unwrap();
-        }
-    }
+    // fn create_if_nonexistent(&mut self) {
+    //     let does_logfile_exist = fs::exists(self.filename
+    //         .clone())
+    //         .unwrap();
+    //     if does_logfile_exist == false {
+    //         self.create_new_log_file().unwrap();
+    //     }
+    // }
 
     fn rotate_log_file(&mut self) {
         // check if file exists
@@ -100,8 +97,8 @@ impl FileSink {
                 self.filename.clone()
             ).unwrap();
             
-            let creation_date = file_metadata.created().unwrap();
-            let duration_since = SystemTime::duration_since(
+            let creation_date: SystemTime = file_metadata.created().unwrap();
+            let duration_since: Duration = SystemTime::duration_since(
                 &SystemTime::now(), 
                 creation_date).unwrap();
 
@@ -133,7 +130,6 @@ impl FileSink {
                 self.rename_existing_log_file().unwrap();
                 self.create_new_log_file().unwrap();
             }
-
         }
         else {
             self.create_new_log_file().unwrap();
@@ -145,9 +141,7 @@ impl FileSink {
     }
 
     fn rename_existing_log_file(&mut self) -> Result<(), Box<dyn Error>> {
-        // let timestamp: chrono::DateTime<Local> = Local::now();
-        let timestamp: String =  utils::generate_timestamp();
-        // modify to unix timestamp
+        let timestamp =  utils::generate_unix_timestamp();
         // TODO - more sophisticated string manipulation!
         let new_logfile_name = format!("alembic.{:?}.log", timestamp);
         let _ = fs::rename(

--- a/src/sinks/stdoutsink.rs
+++ b/src/sinks/stdoutsink.rs
@@ -8,9 +8,12 @@ pub struct StdoutSink {
 }
 
 impl base::LogMessage for StdoutSink {
-    fn log_message(&mut self, message: &String, log_levels: &base::LogLevels) {
-        // generate timestamp
-        let timestamp: chrono::DateTime<Local> = Local::now();
+    fn log_message(
+        &mut self,
+        message: &String,
+        timestamp: chrono::DateTime<Local>,
+        log_levels: &base::LogLevels,
+    ) {
         println!(
             "[{:?}] [{}] [{}] {}",
             timestamp, log_levels, self.type_id, message

--- a/src/sinks/stdoutsink.rs
+++ b/src/sinks/stdoutsink.rs
@@ -10,7 +10,7 @@ pub struct StdoutSink {
 impl base::LogMessage for StdoutSink {
     fn log_message(
         &mut self,
-        message: &String,
+        message: &str,
         timestamp: chrono::DateTime<Local>,
         log_levels: &base::LogLevels,
     ) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-pub fn generate_timestamp() -> String {
+pub fn generate_unix_timestamp() -> u64 {
     let epoch = SystemTime::now();
-    let timestamp: String = epoch.duration_since(UNIX_EPOCH)
+    let timestamp: u64 = epoch.duration_since(UNIX_EPOCH)
         .expect("We are time traveling")
-        .as_secs()
-        .to_string();
+        .as_secs();
     timestamp
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,17 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use chrono::Local;
+
 pub fn generate_unix_timestamp() -> u64 {
     let epoch = SystemTime::now();
-    let timestamp: u64 = epoch.duration_since(UNIX_EPOCH)
+    let timestamp: u64 = epoch
+        .duration_since(UNIX_EPOCH)
         .expect("We are time traveling")
         .as_secs();
+    timestamp
+}
+
+pub fn generate_human_timestamp() -> chrono::DateTime<Local> {
+    let timestamp: chrono::DateTime<Local> = Local::now();
     timestamp
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ pub fn generate_unix_timestamp() -> u64 {
     let epoch = SystemTime::now();
     let timestamp: u64 = epoch
         .duration_since(UNIX_EPOCH)
-        .expect("We are time traveling")
+        .expect("We are time traveling?")
         .as_secs();
     timestamp
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn generate_timestamp() -> String {
+    let epoch = SystemTime::now();
+    let timestamp: String = epoch.duration_since(UNIX_EPOCH)
+        .expect("We are time traveling")
+        .as_secs()
+        .to_string();
+    timestamp
+}


### PR DESCRIPTION
## File sink implementation

This PR aims to complete the implementation of the default `File` output sink option for Alembic.

- Writing to a log file
- Log file rotation policies
  - Hourly
  - Daily
  - Weekly
  - Monthly
 - Centralizes timestamp generation at the Handler level, so all output sinks have identical timestamps
 - Implements `utils.rs` that for now has two functions, `generate_unix_timestamp()` for rotated filenames, and `generate_human_timestamp` for log lines