### PR TITLE
Rename alembic to alembic-log in toml to avoid name collision in carg…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "alembic"
+name = "alembic-log"
 version = "0.1.2"
 dependencies = [
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "alembic"
+name = "alembic-log"
 version = "0.1.2"
 edition = "2021"
 

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fs, path::PathBuf};
 
-use alembic::{
+use alembic_log::{
     handler::Handler,
     sinks::{
         filesink::{self, FileSink, RotationPolicy},


### PR DESCRIPTION
There is already a package called `alembic` in [cargo.io](https://crates.io/crates/alembic), so this slight rename to the package in `Cargo.toml` will help avoid a name collision.

That package is a placeholder at best and hasn't been updated in 5 years (there isn't even any meaningful code in it), so a full name change is not warranted.