### PR TITLE
Added log level support to Handlers, with default level of Error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "alembic-log"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alembic-log"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 repository = "https://github.com/mnowzari/alembic"
 homepage = "https://github.com/mnowzari/alembic"

--- a/README.md
+++ b/README.md
@@ -13,21 +13,23 @@ Currently supported output sinks:
 
 To-do
 - Elasticsearch sink
-- Adjustable log formats
 
 ## Example: Write to a `stdout` and `File` sink simultaneously
 ```rust
-// Create a log handler
+// Create a log handler. Default log level is Error.
 let mut logger: Handler = Handler::new().unwrap();
+
 // Create stdout and file sink instances
 let mut stdout_sink: StdoutSink = Stdout::new().unwrap();
 let mut file_sink: FileSink = FileSink::new(
   PathBuf::from("./my_application.log"),
   alembic::filesink::RotationPolicy::Weekly
 ).unwrap();
+
 // Add the sinks to the log handler
 logger.add_sink(Box::new(stdout_sink));
 logger.add_sink(Box::new(file_sink));
+
 // Write some logs!
 logger.info("Hello, Alembic!")
 logger.error("Oh dear, there's been a terrible error.")
@@ -54,7 +56,7 @@ cargo build
 However, we also have a `Makefile` to make common development actions easier.
 
 ```shell
-make build # development build
+make build         # development build
 make build-release # release build
 ```
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,15 +4,21 @@ use crate::{
     sinks::base::{LogLevels, LogMessage},
     utils::{self},
 };
-use std::error::Error;
+use std::{collections::HashMap, error::Error};
 
 pub struct Handler {
     sinks: Vec<Box<dyn LogMessage>>, // Box dyn that implements the LogMessage trait
+    log_level: u8, // the level at which we should emit logs. Default level is Error
+    level_map: HashMap<LogLevels, u8>, // a mapping of log levels to u8 values for comparison
 }
 
 impl Handler {
     pub fn new() -> Result<Self, Box<dyn Error>> {
-        Ok(Handler { sinks: vec![] })
+        Ok(Handler {
+            sinks: vec![],
+            log_level: 3, // default log level is Error
+            level_map: map_log_levels(),
+        })
     }
 
     pub fn add_sink(&mut self, sink: Box<dyn LogMessage>) {
@@ -25,12 +31,21 @@ impl Handler {
         self.sinks = sinks
     }
 
+    pub fn set_log_level(&mut self, new_log_level: LogLevels) {
+        self.log_level = *self.level_map.get(&new_log_level).unwrap();
+    }
+
     fn log_to_sinks(&mut self, message: &str, log_level: LogLevels) {
         // Generate timestamp here so all sinks have the same timestamp
         let timestamp: chrono::DateTime<Local> = utils::generate_human_timestamp();
 
-        for s in self.sinks.iter_mut() {
-            s.log_message(&String::from(message), timestamp, &log_level);
+        let message_log_level: u8 = *self.level_map.get(&log_level).unwrap();
+
+        // only emit if the message level is greater than or equal to the handler's log level
+        if message_log_level >= self.log_level {
+            for s in self.sinks.iter_mut() {
+                s.log_message(&String::from(message), timestamp, &log_level);
+            }
         }
     }
 
@@ -53,4 +68,14 @@ impl Handler {
     pub fn fatal(&mut self, message: &str) {
         self.log_to_sinks(message, LogLevels::Fatal);
     }
+}
+
+fn map_log_levels() -> HashMap<LogLevels, u8> {
+    let mut level_map: HashMap<LogLevels, u8> = HashMap::new();
+    level_map.insert(LogLevels::Debug, 0);
+    level_map.insert(LogLevels::Info, 1);
+    level_map.insert(LogLevels::Warn, 2);
+    level_map.insert(LogLevels::Error, 3);
+    level_map.insert(LogLevels::Fatal, 4);
+    level_map
 }

--- a/src/sinks/base.rs
+++ b/src/sinks/base.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 use chrono::Local;
 
+#[derive(Eq, PartialEq, Hash)]
 pub enum LogLevels {
     Debug,
     Info,
@@ -21,7 +22,7 @@ impl fmt::Display for LogLevels {
     }
 }
 
-/// All sinks must implement the LogMessage trait.
+// All sinks must implement the LogMessage trait.
 pub trait LogMessage {
     fn log_message(
         &mut self,

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -3,9 +3,7 @@ use std::{error::Error, fs, path::PathBuf};
 use alembic_log::{
     handler::Handler,
     sinks::{
-        filesink::{self, FileSink, RotationPolicy},
-        stderr::StderrSink,
-        stdoutsink::StdoutSink,
+        base::LogLevels, filesink::{self, FileSink, RotationPolicy}, stderr::StderrSink, stdoutsink::StdoutSink
     },
 };
 
@@ -23,8 +21,8 @@ fn log_sender(logger: &mut Handler) -> Result<bool, Box<dyn Error>> {
 
 fn validate_log_lines() -> Result<bool, bool> {
     let log_contents: Vec<u8> = fs::read(FILESINK_FIXTURE).unwrap();
-    match log_contents.len() == 354 {
-        // length of the byte vector
+    // Naive way of checking the contents wrote correctly, accounts for Windows and Linux EoF behavior
+    match log_contents.len() >= 256 && log_contents.len() <= 260 {
         true => Ok(true),
         false => Err(false),
     }
@@ -61,6 +59,7 @@ fn stderr_sink_test() {
 #[test]
 fn filesink_test() {
     let mut logger: Handler = Handler::new().unwrap();
+    logger.set_log_level(LogLevels::Info);
 
     let mut new_file_sink: FileSink = FileSink::new(
         PathBuf::from("./alembic_test_fixture.log"),


### PR DESCRIPTION
# Handlers now support log levels

Logs only emit when they are at or above the current log level of the handler!

Also in this PR:
- naive updates to integration tests to ensure tests run on both Windows and Linux (I think this has to do with EoF behavior differences between the two OSes)